### PR TITLE
feature/choropleth-responsive

### DIFF
--- a/src/components/legend/legend-list/legend-item/legend-item-types/legend-item-type-choropleth/styles.scss
+++ b/src/components/legend/legend-list/legend-item/legend-item-types/legend-item-type-choropleth/styles.scss
@@ -1,3 +1,5 @@
+@import 'settings';
+
 .c-legend-type-choropleth {
   display: flex;
   margin: 0;
@@ -12,7 +14,6 @@
 
   .name {
     display: block;
-
     font-family: 'Helvetica Neue', Arial, sans-serif;
     font-size: 12px;
     text-align: center;
@@ -22,5 +23,29 @@
     display: block;
     height: 5px;
     margin-bottom: 5px;
+  }
+
+  @media screen and (max-width: map-get($breakpoints, small)) {
+    flex-direction: column;
+    margin-top: 10px;
+
+    > li {
+      margin: 0;
+      line-height: 21px;
+    }
+
+    .name {
+      display: inline-block;
+      margin-left: 5px;
+    }
+
+    .icon-choropleth {
+      position: relative;
+      top: 1px;
+      display: inline-block;
+      height: 12px;
+      width: 12px;
+      margin-bottom: 0;
+    }
   }
 }

--- a/src/css/settings.scss
+++ b/src/css/settings.scss
@@ -31,6 +31,10 @@ $font-weight-light: 300;
 $font-weight-regular: 400;
 $font-weight-bold: 700;
 
-
 // Space
 $space-1: 8px;
+
+// Breakpoints
+$breakpoints: (
+  small: 400px
+);


### PR DESCRIPTION
## Overview
With these changes the choropleth legend becomes as the basic legend styles when the device screen is too small.
I've chosen `400px` as a good break point, but probably @mbarrenechea knows a better point.
