### PR TITLE
hide multi layer tooltip when changed

### DIFF
--- a/src/components/legend/legend-list/legend-item/legend-item-toolbar/legend-item-button-layers/index.js
+++ b/src/components/legend/legend-list/legend-item/legend-item-toolbar/legend-item-button-layers/index.js
@@ -38,6 +38,13 @@ class LegendItemButtonLayers extends PureComponent {
     multiLayersActive: this.props.layers.length > 1
   }
 
+  componentWillReceiveProps() {
+    // XXX : Whenever the user fiddles with the legend, make sure to hide the multi layer popup
+    if (this.state.multiLayersActive) {
+      this.setState({ multiLayersActive: false });
+    }
+  }
+
   onTooltipVisibilityChange = (visible) => {
     this.setState({ visibilityHover: false });
     this.setState({ visibilityClick: visible });


### PR DESCRIPTION
https://www.pivotaltracker.com/n/projects/1374154/stories/158365637

We need to hide the multilayer popup if the user interacts with the legend, this will hide it whenever the user interacts with it. 
