### PR TITLE
Feature/css-theming

### DIFF
--- a/src/components/legend/legend-list/legend-item/legend-item-drag/styles.scss
+++ b/src/components/legend/legend-list/legend-item/legend-item-drag/styles.scss
@@ -3,7 +3,7 @@
 .c-legend-handler {
   position: absolute;
   cursor: move;
-  top: 16px;
+  top: 17px;
   left: 8px;
 
   svg { fill: $color-dark-1; }

--- a/src/components/legend/legend-list/legend-item/legend-item-drag/styles.scss
+++ b/src/components/legend/legend-list/legend-item/legend-item-drag/styles.scss
@@ -3,7 +3,7 @@
 .c-legend-handler {
   position: absolute;
   cursor: move;
-  top: 13px;
+  top: 16px;
   left: 8px;
 
   svg { fill: $color-dark-1; }

--- a/src/components/legend/legend-list/legend-item/legend-item-types/legend-item-type-basic/legend-item-type-basic-item/styles.scss
+++ b/src/components/legend/legend-list/legend-item/legend-item-types/legend-item-type-basic/legend-item-type-basic-item/styles.scss
@@ -1,6 +1,7 @@
 .c-legend-item {
   display: flex;
   align-items: flex-start;
+  justify-content: flex-start;
 
   font-family: 'Helvetica Neue', Arial, sans-serif;
   font-size: 12px;

--- a/src/components/legend/legend-list/legend-item/styles.scss
+++ b/src/components/legend/legend-list/legend-item/styles.scss
@@ -18,7 +18,7 @@
 
   .legend-item-container {
     width: 100%;
-    padding: 12px 15px;
+    padding: 15px;
 
     &.-sortable {
       padding-left: 28px;

--- a/src/components/legend/legend-list/legend-item/styles.scss
+++ b/src/components/legend/legend-list/legend-item/styles.scss
@@ -18,7 +18,7 @@
 
   .legend-item-container {
     width: 100%;
-    padding: $space-1 * 2;
+    padding: 12px 15px;
 
     &.-sortable {
       padding-left: 28px;

--- a/styleguide.webpack.js
+++ b/styleguide.webpack.js
@@ -16,7 +16,7 @@ module.exports = {
         test: /\.scss$/,
         use: [
           'style-loader',
-          'css-loader?modules&importLoaders=1&localIdentName=[path]___[name]__[local]___[hash:base64:5]',
+          'css-loader?modules&importLoaders=1&localIdentName=wri_api__[local]',
           'resolve-url-loader',
           {
             loader: 'sass-loader',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -34,7 +34,7 @@ const config = {
               options: {
                 modules: true,
                 importLoaders: 1,
-                localIdentName: '[path]___[name]__[local]___[hash:base64:5]'
+                localIdentName: 'wri_api__[local]'
               }
             },
             {


### PR DESCRIPTION
This removes the complex hashing of the CSS modules plugin in order to simplify the component for theming. By doing so you can now override styles in the component locally in your application.

This is not an ideal solution, but due to the extensive implementation of CSS modules and the lack of options for theming with this structure this has been done to avoid a refactor.

A prefix of `wri_api__` has been added to all classes to keep them scoped.