### PR TITLE
Feature/slider opacity update

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   "dependencies": {
     "layer-manager": "^1.0.4",
     "prop-types": "^15.6.2",
+    "rc-slider": "^8.6.1",
     "rc-tooltip": "3.7.0",
     "react-css-modules": "^4.7.1",
     "react-input-range": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "rc-slider": "^8.6.1",
     "rc-tooltip": "3.7.0",
     "react-css-modules": "^4.7.1",
-    "react-input-range": "1.3.0",
     "react-sortable-hoc": "^0.6.8",
     "wri-json-api-serializer": "^1.0.1"
   },

--- a/src/components/form/range/index.js
+++ b/src/components/form/range/index.js
@@ -10,17 +10,25 @@ import styles from './styles.scss';
 export class Range extends React.PureComponent {
   constructor(props) {
     super(props);
-    this.state = {
-      value: props.value
-    };
+    this.state = { value: props.value };
   }
 
   render() {
+    const { color } = this.props;
     return (
       <Slider
+        trackStyle={[
+          { backgroundColor: color || '#c32d7b' },
+          { backgroundColor: 'grey' }
+        ]}
+        handleStyle={[
+          { backgroundColor: color || '#c32d7b', width: '14px', height: '14px', border: 0 }
+        ]}
+        activeDotStyle={{ display: 'none' }}
+        dotStyle={{ display: 'none' }}
         {...this.props}
         value={this.state.value}
-        onChange={value => { this.setState({ value }); }}
+        onChange={value => this.setState({ value })}
       />
     );
   }

--- a/src/components/form/range/index.js
+++ b/src/components/form/range/index.js
@@ -2,16 +2,25 @@ import React from 'react';
 import CSSModules from 'react-css-modules';
 
 // Range
-import RRange from 'react-input-range';
+import Slider from 'rc-slider';
 
 // Styles
 import styles from './styles.scss';
 
 export class Range extends React.PureComponent {
+  constructor(props) {
+    super(props);
+    this.state = {
+      value: props.value
+    };
+  }
+
   render() {
     return (
-      <RRange
+      <Slider
         {...this.props}
+        value={this.state.value}
+        onChange={value => { this.setState({ value }); }}
       />
     );
   }

--- a/src/components/form/range/index.js
+++ b/src/components/form/range/index.js
@@ -14,15 +14,14 @@ export class Range extends React.PureComponent {
   }
 
   render() {
-    const { color } = this.props;
     return (
       <Slider
         trackStyle={[
-          { backgroundColor: color || '#c32d7b' },
+          { backgroundColor: '#c32d7b' },
           { backgroundColor: 'grey' }
         ]}
         handleStyle={[
-          { backgroundColor: color || '#c32d7b', width: '14px', height: '14px', border: 0 }
+          { backgroundColor: '#c32d7b', width: '14px', height: '14px', border: 0 }
         ]}
         activeDotStyle={{ display: 'none' }}
         dotStyle={{ display: 'none' }}

--- a/src/components/form/range/styles.scss
+++ b/src/components/form/range/styles.scss
@@ -2,52 +2,10 @@
 
 // Input range styles
 :global {
-  @import 'react-input-range/src/scss/index.scss';
-
-  .input-range__label {
-    font-size: 8px;
-    color: $color-dark-2;
-    top: -24px;
-  }
-
-  .input-range__slider {
-    border: 0;
-    background-color: $color-primary;
-    width: 14px;
-    height: 14px;
-    margin-top: -9px;
-  }
-
-  .input-range__track {
-    height: 3px;
-
-    &:before {
-      content: "";
-      position: absolute;
-      top: 50%;
-      left: 50%;
-      height: 1000%;
-      width: 100%;
-      transform: translate(-50%, -50%);
-    }
-  }
-
-  .input-range__track--background {
-    margin-left: 12px;
-    margin-right: 12px;
-  }
-
-  .input-range__track--active {
-    background-color: $color-primary;
-  }
-
-  .input-range__label--min, .input-range__label--max {
-    font-size: 10px;
-    top: auto;
-    bottom: -16px;
-
-    .input-range__label-container {
-      left: 0;
+  .rc-slider-handle {
+    &:focus,
+    &:active {
+      outline: none;
     }
   }
 }

--- a/src/components/icon/index.js
+++ b/src/components/icon/index.js
@@ -8,21 +8,23 @@ import styles from './styles.scss';
 export class Icon extends React.PureComponent {
   static propTypes = {
     name: PropTypes.string,
-    className: PropTypes.string
+    className: PropTypes.string,
+    style: PropTypes.object
   };
 
   static defaultProps = {
     name: '',
-    className: ''
+    className: '',
+    style: {}
   };
 
   render() {
-    const { name, className } = this.props;
+    const { name, className, style } = this.props;
 
     const classNames = classnames({ [className]: !!className });
 
     return (
-      <svg styleName={`c-icon ${classNames}`}>
+      <svg styleName={`c-icon ${classNames}`} style={style}>
         <use xlinkHref={`#${name}`} />
       </svg>
     );

--- a/src/components/legend/components/legend-item-toolbar/index.js
+++ b/src/components/legend/components/legend-item-toolbar/index.js
@@ -17,6 +17,10 @@ export class LegendItemToolbar extends PureComponent {
   static propTypes = {
     // Props
     children: PropTypes.node,
+    enabledStyle: PropTypes.object,
+    defaultStyle: PropTypes.object,
+    disabledStyle: PropTypes.object,
+    focusStyle: PropTypes.object,
 
     // ACTIONS
     onChangeBBox: PropTypes.func,
@@ -30,6 +34,18 @@ export class LegendItemToolbar extends PureComponent {
   static defaultProps = {
     // Props
     children: [],
+    defaultStyle: {
+      fill: '#717171'
+    },
+    enabledStyle: {
+      fill: '#2C75B0'
+    },
+    disabledStyle: {
+      fill: '#CACCD0'
+    },
+    focusStyle: {
+      fill: '#393f44'
+    },
 
     // ACTIONS
     onChangeBBox: l => console.info(l),

--- a/src/components/legend/components/legend-item-toolbar/legend-item-button-bbox/index.js
+++ b/src/components/legend/components/legend-item-toolbar/legend-item-button-bbox/index.js
@@ -16,6 +16,8 @@ class LegendItemButtonBBox extends PureComponent {
     activeLayer: PropTypes.object,
     tooltipOpened: PropTypes.bool,
     icon: PropTypes.string,
+    focusStyle: PropTypes.object,
+    defaultStyle: PropTypes.object,
 
     onChangeBBox: PropTypes.func
   }
@@ -24,13 +26,19 @@ class LegendItemButtonBBox extends PureComponent {
     activeLayer: {},
     tooltipOpened: false,
     icon: '',
+    focusStyle: {},
+    defaultStyle: {},
 
     onChangeBBox: () => {}
   }
 
-  render() {
-    const { activeLayer, tooltipOpened, icon } = this.props;
+  state = {
+    visible: false
+  }
 
+  render() {
+    const { activeLayer, tooltipOpened, icon, focusStyle, defaultStyle } = this.props;
+    const { visible } = this.state;
     if (activeLayer.layerConfig && !activeLayer.layerConfig.bbox) {
       return null;
     }
@@ -43,6 +51,8 @@ class LegendItemButtonBBox extends PureComponent {
         trigger={tooltipOpened ? '' : 'hover'}
         mouseLeaveDelay={0}
         destroyTooltipOnHide
+        onVisibleChange={v => this.setState({ visible: v })}
+        visible={visible}
       >
         <button
           type="button"
@@ -50,7 +60,7 @@ class LegendItemButtonBBox extends PureComponent {
           aria-label="Fit to bounds"
           onClick={() => this.props.onChangeBBox(activeLayer)}
         >
-          <Icon name={icon || 'icon-bbox'} className="-small" />
+          <Icon name={icon || 'icon-bbox'} className="-small" style={visible ? focusStyle : defaultStyle} />
         </button>
       </Tooltip>
     );

--- a/src/components/legend/components/legend-item-toolbar/legend-item-button-info/index.js
+++ b/src/components/legend/components/legend-item-toolbar/legend-item-button-info/index.js
@@ -14,6 +14,8 @@ class LegendItemButtonInfo extends PureComponent {
     activeLayer: PropTypes.object,
     tooltipOpened: PropTypes.bool,
     icon: PropTypes.string,
+    focusStyle: PropTypes.object,
+    defaultStyle: PropTypes.object,
 
     // ACTIONS
     onChangeInfo: PropTypes.func
@@ -23,12 +25,19 @@ class LegendItemButtonInfo extends PureComponent {
     activeLayer: {},
     tooltipOpened: false,
     icon: '',
+    focusStyle: {},
+    defaultStyle: {},
 
     onChangeInfo: () => {}
   }
 
+  state = {
+    visible: false
+  }
+
   render() {
-    const { activeLayer, tooltipOpened, icon } = this.props;
+    const { activeLayer, tooltipOpened, icon, focusStyle, defaultStyle } = this.props;
+    const { visible } = this.state;
 
     return (
       <Tooltip
@@ -38,6 +47,9 @@ class LegendItemButtonInfo extends PureComponent {
         trigger={tooltipOpened ? '' : 'hover'}
         mouseLeaveDelay={0}
         destroyTooltipOnHide
+        onVisibleChange={v => this.setState({ visible: v })}
+        visible={visible}
+
       >
         <button
           type="button"
@@ -45,7 +57,7 @@ class LegendItemButtonInfo extends PureComponent {
           aria-label="More information"
           onClick={() => this.props.onChangeInfo(activeLayer)}
         >
-          <Icon name={icon || 'icon-info'} className="-small" />
+          <Icon name={icon || 'icon-info'} className="-small" style={visible ? focusStyle : defaultStyle} />
         </button>
       </Tooltip>
     );

--- a/src/components/legend/components/legend-item-toolbar/legend-item-button-layers/index.js
+++ b/src/components/legend/components/legend-item-toolbar/legend-item-button-layers/index.js
@@ -89,7 +89,7 @@ class LegendItemButtonLayers extends PureComponent {
             onChangeLayer={this.props.onChangeLayer}
           />
         }
-        overlayClassName="c-rc-tooltip -default"
+        overlayClassName="c-rc-tooltip -default -layers"
         placement="top"
         trigger={['click']}
         destroyTooltipOnHide

--- a/src/components/legend/components/legend-item-toolbar/legend-item-button-layers/index.js
+++ b/src/components/legend/components/legend-item-toolbar/legend-item-button-layers/index.js
@@ -17,8 +17,9 @@ class LegendItemButtonLayers extends PureComponent {
   static propTypes = {
     layers: PropTypes.array,
     activeLayer: PropTypes.object,
-    tooltipOpened: PropTypes.bool,
     icon: PropTypes.string,
+    focusStyle: PropTypes.object,
+    defaultStyle: PropTypes.object,
 
     onChangeLayer: PropTypes.func,
     onTooltipVisibilityChange: PropTypes.func
@@ -27,8 +28,9 @@ class LegendItemButtonLayers extends PureComponent {
   static defaultProps = {
     layers: [],
     activeLayer: {},
-    tooltipOpened: false,
     icon: '',
+    focusStyle: {},
+    defaultStyle: {},
 
     onChangeLayer: () => {},
     onTooltipVisibilityChange: () => {}
@@ -72,7 +74,7 @@ class LegendItemButtonLayers extends PureComponent {
   }
 
   render() {
-    const { layers, activeLayer, tooltipOpened, icon } = this.props;
+    const { layers, activeLayer, icon, focusStyle, defaultStyle } = this.props;
     const { visibilityClick, visibilityHover, multiLayersActive } = this.state;
     const timelineLayers = this.getTimelineLayers();
 
@@ -93,24 +95,24 @@ class LegendItemButtonLayers extends PureComponent {
         placement="top"
         trigger={['click']}
         destroyTooltipOnHide
-        onVisibilityChange={this.onTooltipVisibilityChange}
+        onVisibleChange={this.onTooltipVisibilityChange}
       >
 
         <Tooltip
-          visibility={(!visibilityClick && visibilityHover) || multiLayersActive}
+          visibile={(!visibilityClick && visibilityHover) || multiLayersActive}
           overlay={multiLayersActive ? `${layers.length} layers` : 'Layers'}
           overlayClassName="c-rc-tooltip -default"
           placement="top"
-          trigger={tooltipOpened ? '' : 'hover'}
-          onVisibilityChange={visibility => this.setState({ visibilityHover: visibility })}
+          onVisibleChange={visibility => this.setState({ visibilityHover: visibility })}
           destroyTooltipOnHide
+          visible={visibilityHover && !visibilityClick}
         >
           <button
             type="button"
             styleName="c-legend-button layers"
             aria-label="Select other layer"
           >
-            <Icon name={icon || 'icon-layers'} className="-small" />
+            <Icon name={icon || 'icon-layers'} className="-small" style={visibilityHover || visibilityClick ? focusStyle : defaultStyle} />
           </button>
         </Tooltip>
       </Tooltip>

--- a/src/components/legend/components/legend-item-toolbar/legend-item-button-opacity/index.js
+++ b/src/components/legend/components/legend-item-toolbar/legend-item-button-opacity/index.js
@@ -20,7 +20,11 @@ class LegendItemButtonOpacity extends PureComponent {
     visibility: PropTypes.bool,
     tooltipOpened: PropTypes.bool,
     icon: PropTypes.string,
-    color: PropTypes.string,
+    className: PropTypes.string,
+    focusStyle: PropTypes.object,
+    defaultStyle: PropTypes.object,
+    enabledStyle: PropTypes.object,
+    disabledStyle: PropTypes.object,
 
     onChangeOpacity: PropTypes.func,
     onTooltipVisibilityChange: PropTypes.func
@@ -32,7 +36,11 @@ class LegendItemButtonOpacity extends PureComponent {
     visibility: true,
     tooltipOpened: false,
     icon: '',
-    color: null,
+    className: '',
+    focusStyle: {},
+    defaultStyle: {},
+    enabledStyle: {},
+    disabledStyle: {},
 
     onChangeOpacity: () => {},
     onTooltipVisibilityChange: () => {}
@@ -50,9 +58,27 @@ class LegendItemButtonOpacity extends PureComponent {
   }
 
   render() {
-    const { layers, visibility, activeLayer, tooltipOpened, icon, color, className, ...rest } = this.props;
+    const {
+      layers,
+      visibility,
+      activeLayer,
+      tooltipOpened,
+      icon,
+      className,
+      enabledStyle,
+      defaultStyle,
+      disabledStyle,
+      focusStyle,
+      ...rest
+    } = this.props;
+
     const { visibilityClick, visibilityHover } = this.state;
     const { opacity } = activeLayer;
+    let iconStyle = visibility ? defaultStyle : disabledStyle;
+    if (visibility && (visibilityHover || visibilityClick)) {
+      iconStyle = focusStyle;
+    }
+    if (visibility && opacity < 1) iconStyle = enabledStyle;
 
     return (
       <Tooltip
@@ -62,7 +88,6 @@ class LegendItemButtonOpacity extends PureComponent {
               layers={layers}
               activeLayer={activeLayer}
               onChangeOpacity={this.props.onChangeOpacity}
-              color={color}
               {...rest}
             />
         }
@@ -74,19 +99,20 @@ class LegendItemButtonOpacity extends PureComponent {
         destroyTooltipOnHide
       >
         <Tooltip
-          visible={visibilityHover && !visibilityClick}
+          visible={visibilityHover && !visibilityClick && visibility}
           overlay={`Opacity ${opacity ? `(${opacity})` : ''}`}
           overlayClassName="c-rc-tooltip -default"
           placement="top"
           onVisibleChange={v => this.setState({ visibilityHover: v })}
           destroyTooltipOnHide
+          style={styles.tooltip}
         >
           <button
             type="button"
             styleName={`c-legend-button opacity ${classnames({ '-disabled': !visibility })}`}
             aria-label="Change opacity"
           >
-            <Icon name={icon || 'icon-opacity'} className="-small" />
+            <Icon name={icon || 'icon-opacity'} className="-small" style={iconStyle} />
           </button>
         </Tooltip>
 

--- a/src/components/legend/components/legend-item-toolbar/legend-item-button-opacity/index.js
+++ b/src/components/legend/components/legend-item-toolbar/legend-item-button-opacity/index.js
@@ -20,6 +20,7 @@ class LegendItemButtonOpacity extends PureComponent {
     visibility: PropTypes.bool,
     tooltipOpened: PropTypes.bool,
     icon: PropTypes.string,
+    color: PropTypes.string,
 
     onChangeOpacity: PropTypes.func,
     onTooltipVisibilityChange: PropTypes.func
@@ -31,6 +32,7 @@ class LegendItemButtonOpacity extends PureComponent {
     visibility: true,
     tooltipOpened: false,
     icon: '',
+    color: null,
 
     onChangeOpacity: () => {},
     onTooltipVisibilityChange: () => {}
@@ -48,7 +50,7 @@ class LegendItemButtonOpacity extends PureComponent {
   }
 
   render() {
-    const { layers, visibility, activeLayer, tooltipOpened, icon } = this.props;
+    const { layers, visibility, activeLayer, tooltipOpened, icon, color } = this.props;
     const { visibilityClick, visibilityHover } = this.state;
 
     return (
@@ -59,9 +61,10 @@ class LegendItemButtonOpacity extends PureComponent {
               layers={layers}
               activeLayer={activeLayer}
               onChangeOpacity={this.props.onChangeOpacity}
+              color={color}
             />
         }
-        overlayClassName={`c-rc-tooltip ${classnames({ '-default': visibility })}`}
+        overlayClassName={`c-rc-tooltip ${classnames({ '-default': visibility })} -opacity`}
         placement="top"
         trigger={['click']}
         onVisibilityChange={this.onTooltipVisibilityChange}

--- a/src/components/legend/components/legend-item-toolbar/legend-item-button-opacity/index.js
+++ b/src/components/legend/components/legend-item-toolbar/legend-item-button-opacity/index.js
@@ -50,8 +50,9 @@ class LegendItemButtonOpacity extends PureComponent {
   }
 
   render() {
-    const { layers, visibility, activeLayer, tooltipOpened, icon, color } = this.props;
+    const { layers, visibility, activeLayer, tooltipOpened, icon, color, ...rest } = this.props;
     const { visibilityClick, visibilityHover } = this.state;
+    const { opacity } = activeLayer;
 
     return (
       <Tooltip
@@ -62,21 +63,22 @@ class LegendItemButtonOpacity extends PureComponent {
               activeLayer={activeLayer}
               onChangeOpacity={this.props.onChangeOpacity}
               color={color}
+              {...rest}
             />
         }
+        visible={visibility && visibilityClick}
         overlayClassName={`c-rc-tooltip ${classnames({ '-default': visibility })} -opacity`}
         placement="top"
         trigger={['click']}
-        onVisibilityChange={this.onTooltipVisibilityChange}
+        onVisibleChange={this.onTooltipVisibilityChange}
         destroyTooltipOnHide
       >
         <Tooltip
-          visibility={!visibilityClick && visibilityHover}
-          overlay="Opacity"
+          visible={visibilityHover && !visibilityClick}
+          overlay={`Opacity ${opacity ? `(${opacity})` : ''}`}
           overlayClassName="c-rc-tooltip -default"
           placement="top"
-          trigger={tooltipOpened ? '' : 'hover'}
-          onVisibilityChange={v => this.setState({ visibilityHover: v })}
+          onVisibleChange={v => this.setState({ visibilityHover: v })}
           destroyTooltipOnHide
         >
           <button

--- a/src/components/legend/components/legend-item-toolbar/legend-item-button-opacity/index.js
+++ b/src/components/legend/components/legend-item-toolbar/legend-item-button-opacity/index.js
@@ -50,7 +50,7 @@ class LegendItemButtonOpacity extends PureComponent {
   }
 
   render() {
-    const { layers, visibility, activeLayer, tooltipOpened, icon, color, ...rest } = this.props;
+    const { layers, visibility, activeLayer, tooltipOpened, icon, color, className, ...rest } = this.props;
     const { visibilityClick, visibilityHover } = this.state;
     const { opacity } = activeLayer;
 
@@ -67,7 +67,7 @@ class LegendItemButtonOpacity extends PureComponent {
             />
         }
         visible={visibility && visibilityClick}
-        overlayClassName={`c-rc-tooltip ${classnames({ '-default': visibility })} -opacity`}
+        overlayClassName={`c-rc-tooltip ${classnames({ '-default': visibility })} ${className || ''}`}
         placement="top"
         trigger={['click']}
         onVisibleChange={this.onTooltipVisibilityChange}

--- a/src/components/legend/components/legend-item-toolbar/legend-item-button-opacity/legend-item-button-opacity-tooltip/index.js
+++ b/src/components/legend/components/legend-item-toolbar/legend-item-button-opacity/legend-item-button-opacity-tooltip/index.js
@@ -15,6 +15,7 @@ class LegendOpacityTooltip extends React.Component {
     min: PropTypes.number,
     max: PropTypes.number,
     step: PropTypes.number,
+    color: PropTypes.string,
     // Callback to call when the layer changes with
     // the ID of the dataset and the ID of the layer
     onChangeOpacity: PropTypes.func.isRequired
@@ -23,21 +24,18 @@ class LegendOpacityTooltip extends React.Component {
   static defaultProps = {
     min: 0,
     max: 1,
-    step: 0.01
+    step: 0.01,
+    color: null
   }
-
-  state = { value: this.props.activeLayer.opacity || 1 }
 
   onChange = (v) => {
     const { activeLayer } = this.props;
 
-    this.setState({ value: v });
     this.props.onChangeOpacity(activeLayer, v);
   }
 
   render() {
-    const { min, max, step } = this.props;
-    const { value } = this.state;
+    const { min, max, step, color, activeLayer: { opacity } } = this.props;
 
     return (
       <div styleName="c-legend-item-button-opacity-tooltip" ref={(node) => { this.el = node; }}>
@@ -45,18 +43,20 @@ class LegendOpacityTooltip extends React.Component {
 
         <div styleName="slider-tooltip-container">
           <Range
-            minValue={min}
-            maxValue={max}
-            step={step}
-            value={value}
-            formatLabel={(v, string) => {
-              if (string === 'value') {
-                return null;
-              }
-
-              return v.toFixed(2);
+            marks={{
+              [min]: '0',
+              [max]: '1.00'
             }}
-            onChange={this.onChange}
+            min={min}
+            max={max}
+            step={step}
+            value={opacity}
+            trackStyle={[
+              { backgroundColor: color },
+              { backgroundColor: 'grey' }
+            ]}
+            color={color}
+            onAfterChange={this.onChange}
           />
         </div>
       </div>

--- a/src/components/legend/components/legend-item-toolbar/legend-item-button-opacity/legend-item-button-opacity-tooltip/index.js
+++ b/src/components/legend/components/legend-item-toolbar/legend-item-button-opacity/legend-item-button-opacity-tooltip/index.js
@@ -15,7 +15,6 @@ class LegendOpacityTooltip extends React.Component {
     min: PropTypes.number,
     max: PropTypes.number,
     step: PropTypes.number,
-    color: PropTypes.string,
     // Callback to call when the layer changes with
     // the ID of the dataset and the ID of the layer
     onChangeOpacity: PropTypes.func.isRequired
@@ -24,8 +23,7 @@ class LegendOpacityTooltip extends React.Component {
   static defaultProps = {
     min: 0,
     max: 1,
-    step: 0.01,
-    color: null
+    step: 0.01
   }
 
   onChange = (v) => {
@@ -35,7 +33,7 @@ class LegendOpacityTooltip extends React.Component {
   }
 
   render() {
-    const { min, max, step, color, activeLayer: { opacity }, ...rest } = this.props;
+    const { min, max, step, activeLayer: { opacity }, ...rest } = this.props;
 
     return (
       <div styleName="c-legend-item-button-opacity-tooltip" ref={(node) => { this.el = node; }}>
@@ -51,7 +49,6 @@ class LegendOpacityTooltip extends React.Component {
             max={max}
             step={step}
             value={opacity}
-            color={color}
             onAfterChange={this.onChange}
             {...rest}
           />

--- a/src/components/legend/components/legend-item-toolbar/legend-item-button-opacity/legend-item-button-opacity-tooltip/index.js
+++ b/src/components/legend/components/legend-item-toolbar/legend-item-button-opacity/legend-item-button-opacity-tooltip/index.js
@@ -35,7 +35,7 @@ class LegendOpacityTooltip extends React.Component {
   }
 
   render() {
-    const { min, max, step, color, activeLayer: { opacity } } = this.props;
+    const { min, max, step, color, activeLayer: { opacity }, ...rest } = this.props;
 
     return (
       <div styleName="c-legend-item-button-opacity-tooltip" ref={(node) => { this.el = node; }}>
@@ -51,12 +51,9 @@ class LegendOpacityTooltip extends React.Component {
             max={max}
             step={step}
             value={opacity}
-            trackStyle={[
-              { backgroundColor: color },
-              { backgroundColor: 'grey' }
-            ]}
             color={color}
             onAfterChange={this.onChange}
+            {...rest}
           />
         </div>
       </div>

--- a/src/components/legend/components/legend-item-toolbar/legend-item-button-opacity/legend-item-button-opacity-tooltip/styles.scss
+++ b/src/components/legend/components/legend-item-toolbar/legend-item-button-opacity/legend-item-button-opacity-tooltip/styles.scss
@@ -1,6 +1,6 @@
 .c-legend-item-button-opacity-tooltip {
   .slider-tooltip-container {
-    padding: 12px 0;
+    padding: 12px 0 20px;
     min-width: 150px;
   }
 }

--- a/src/components/legend/components/legend-item-toolbar/legend-item-button-remove/index.js
+++ b/src/components/legend/components/legend-item-toolbar/legend-item-button-remove/index.js
@@ -16,6 +16,8 @@ class LegendItemButtonRemove extends PureComponent {
     activeLayer: PropTypes.object,
     tooltipOpened: PropTypes.bool,
     icon: PropTypes.string,
+    focusStyle: PropTypes.object,
+    defaultStyle: PropTypes.object,
 
     // ACTIONS
     onRemoveLayer: PropTypes.func
@@ -25,13 +27,20 @@ class LegendItemButtonRemove extends PureComponent {
     activeLayer: {},
     tooltipOpened: false,
     icon: '',
+    focusStyle: {},
+    defaultStyle: {},
 
     // ACTIONS
     onRemoveLayer: () => {}
   }
 
+  state = {
+    visible: false
+  }
+
   render() {
-    const { activeLayer, tooltipOpened, icon } = this.props;
+    const { activeLayer, tooltipOpened, icon, focusStyle, defaultStyle } = this.props;
+    const { visible } = this.state;
 
     return (
       <Tooltip
@@ -41,6 +50,8 @@ class LegendItemButtonRemove extends PureComponent {
         trigger={tooltipOpened ? '' : 'hover'}
         mouseLeaveDelay={0}
         destroyTooltipOnHide
+        onVisibleChange={v => this.setState({ visible: v })}
+        visible={visible}
       >
         <button
           type="button"
@@ -48,7 +59,7 @@ class LegendItemButtonRemove extends PureComponent {
           onClick={() => this.props.onRemoveLayer(activeLayer)}
           aria-label="Remove"
         >
-          <Icon name={icon || 'icon-cross'} className="-small" />
+          <Icon name={icon || 'icon-cross'} className="-small" style={visible ? focusStyle : defaultStyle} />
         </button>
       </Tooltip>
     );

--- a/src/components/legend/components/legend-item-toolbar/legend-item-button-visibility/index.js
+++ b/src/components/legend/components/legend-item-toolbar/legend-item-button-visibility/index.js
@@ -18,7 +18,9 @@ class LegendItemButtonVisibility extends PureComponent {
     tooltipOpened: PropTypes.bool,
     onChangeVisibility: PropTypes.func,
     iconShow: PropTypes.string,
-    iconHide: PropTypes.string
+    iconHide: PropTypes.string,
+    focusStyle: PropTypes.object,
+    defaultStyle: PropTypes.object
   }
 
   static defaultProps = {
@@ -27,11 +29,19 @@ class LegendItemButtonVisibility extends PureComponent {
     tooltipOpened: false,
     iconShow: '',
     iconHide: '',
+    focusStyle: {},
+    defaultStyle: {},
+
     onChangeVisibility: () => {}
   }
 
+  state = {
+    visible: false
+  }
+
   render() {
-    const { activeLayer, visibility, tooltipOpened, iconShow, iconHide } = this.props;
+    const { activeLayer, visibility, tooltipOpened, iconShow, iconHide, focusStyle, defaultStyle } = this.props;
+    const { visible } = this.state;
 
     const showIcon = iconShow || 'icon-show';
     const hideIcon = iconHide || 'icon-hide';
@@ -45,6 +55,8 @@ class LegendItemButtonVisibility extends PureComponent {
         trigger={tooltipOpened ? '' : 'hover'}
         mouseLeaveDelay={0}
         destroyTooltipOnHide
+        onVisibleChange={v => this.setState({ visible: v })}
+        visible={visible}
       >
         <button
           type="button"
@@ -52,7 +64,7 @@ class LegendItemButtonVisibility extends PureComponent {
           onClick={() => this.props.onChangeVisibility(activeLayer, !visibility)}
           aria-label="Toggle the visibility"
         >
-          <Icon name={activeIcon} className="-small" />
+          <Icon name={activeIcon} className="-small" style={visible ? focusStyle : defaultStyle} />
         </button>
       </Tooltip>
     );

--- a/src/components/legend/components/legend-item-toolbar/styles-button.scss
+++ b/src/components/legend/components/legend-item-toolbar/styles-button.scss
@@ -17,12 +17,8 @@
   }
 
   &.-disabled {
-    cursor: default;
-    opacity: .5;
-
-    &:hover svg {
-      fill: $color-dark-1;
-    }
+    cursor: not-allowed;
+    pointer-events: none;
   }
 
   // Icons

--- a/src/components/legend/components/legend-item-toolbar/styles-button.scss
+++ b/src/components/legend/components/legend-item-toolbar/styles-button.scss
@@ -8,17 +8,8 @@
   cursor: pointer;
   outline: none;
 
-  svg {
-    fill: $color-dark-1;
-  }
-
-  &:hover svg {
-    fill: $color-secondary;
-  }
-
   &.-disabled {
     cursor: not-allowed;
-    pointer-events: none;
   }
 
   // Icons
@@ -26,6 +17,6 @@
   &.info { svg { width: 14px; } }
   &.close { svg { width: 11px; } }
   &.toggle { svg { width: 16px; } }
-  &.opacity { svg { width: 11px; } }
+  &.opacity { svg { width: 13px; } }
   &.layers { svg { width: 15px; } }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5718,7 +5718,7 @@ prop-types@15.x, prop-types@^15.5.10, prop-types@^15.5.7, prop-types@^15.5.8, pr
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
-prop-types@^15.6.2:
+prop-types@^15.5.4, prop-types@^15.6.2:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
   dependencies:
@@ -5875,9 +5875,29 @@ rc-animate@2.x:
     css-animation "^1.3.2"
     prop-types "15.x"
 
+rc-slider@^8.6.1:
+  version "8.6.1"
+  resolved "https://registry.yarnpkg.com/rc-slider/-/rc-slider-8.6.1.tgz#ee5e0380dbdf4b5de6955a265b0d4ff6196405d1"
+  dependencies:
+    babel-runtime "6.x"
+    classnames "^2.2.5"
+    prop-types "^15.5.4"
+    rc-tooltip "^3.7.0"
+    rc-util "^4.0.4"
+    shallowequal "^1.0.1"
+    warning "^3.0.0"
+
 rc-tooltip@3.7.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/rc-tooltip/-/rc-tooltip-3.7.0.tgz#3afbf109865f7cdcfe43752f3f3f501f7be37aaa"
+  dependencies:
+    babel-runtime "6.x"
+    prop-types "^15.5.8"
+    rc-trigger "^2.2.2"
+
+rc-tooltip@^3.7.0:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/rc-tooltip/-/rc-tooltip-3.7.2.tgz#3698656d4bacd51b72d9e327bed15d1d5a9f1b27"
   dependencies:
     babel-runtime "6.x"
     prop-types "^15.5.8"
@@ -6728,6 +6748,10 @@ shallowequal@^0.2.2:
   resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-0.2.2.tgz#1e32fd5bcab6ad688a4812cb0cc04efc75c7014e"
   dependencies:
     lodash.keys "^3.1.2"
+
+shallowequal@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
 
 shebang-command@^1.2.0:
   version "1.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -408,10 +408,6 @@ atob@~1.1.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/atob/-/atob-1.1.3.tgz#95f13629b12c3a51a5d215abdce2aa9f32f80773"
 
-autobind-decorator@^1.3.4:
-  version "1.4.3"
-  resolved "https://registry.yarnpkg.com/autobind-decorator/-/autobind-decorator-1.4.3.tgz#4c96ffa77b10622ede24f110f5dbbf56691417d1"
-
 autoprefixer@^6.3.1:
   version "6.7.7"
   resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-6.7.7.tgz#1dbd1c835658e35ce3f9984099db00585c782014"
@@ -6016,13 +6012,6 @@ react-icons@^2.2.7:
   resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-2.2.7.tgz#d7860826b258557510dac10680abea5ca23cf650"
   dependencies:
     react-icon-base "2.1.0"
-
-react-input-range@1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/react-input-range/-/react-input-range-1.3.0.tgz#f96d001631ab817417f1e26d8f9f9684b4827f59"
-  dependencies:
-    autobind-decorator "^1.3.4"
-    prop-types "^15.5.8"
 
 react-sortable-hoc@^0.6.8:
   version "0.6.8"


### PR DESCRIPTION
Firstly this PR addresses bugs with the `LegendItemOpacityButton` component and its corresponding tooltips. There were the following issues:
- The `visible` prop for rc-tooltip was being used incorrectly allowing the hover tooltip to always show
- The `onVisibleChange` was spelt incorrectly preventing state updates when clicking on the button
- The `Range` components local state when sliding and control props were being managed from the outside leading to a jumpy ui experience and also wasting everyones time updating two props when the component would only like one (please).

These issues have been fixed and the components updated to make the component worthy of production again.

BONUS update includes:
- Updated the `Range` component to use `rc-slider` instead of `react-input-range` due to its simplicity and easily customisable styles. Now style props can be passed to this to allow for app specific slider styles.
- Added a `className` prop to the `LegendItemOpacityButton` component as this tooltip has different styles to the others so might need to be altered in a different way.
- Small style fixes for button hover when disabled.