### PR TITLE
Feature/custom toolbar tooltip text

### DIFF
--- a/src/components/legend/components/legend-item-toolbar/legend-item-button-bbox/index.js
+++ b/src/components/legend/components/legend-item-toolbar/legend-item-button-bbox/index.js
@@ -18,6 +18,7 @@ class LegendItemButtonBBox extends PureComponent {
     icon: PropTypes.string,
     focusStyle: PropTypes.object,
     defaultStyle: PropTypes.object,
+    tooltipText: PropTypes.string,
 
     onChangeBBox: PropTypes.func
   }
@@ -28,6 +29,7 @@ class LegendItemButtonBBox extends PureComponent {
     icon: '',
     focusStyle: {},
     defaultStyle: {},
+    tooltipText: '',
 
     onChangeBBox: () => {}
   }
@@ -37,7 +39,7 @@ class LegendItemButtonBBox extends PureComponent {
   }
 
   render() {
-    const { activeLayer, tooltipOpened, icon, focusStyle, defaultStyle } = this.props;
+    const { activeLayer, tooltipOpened, icon, focusStyle, defaultStyle, tooltipText } = this.props;
     const { visible } = this.state;
     if (activeLayer.layerConfig && !activeLayer.layerConfig.bbox) {
       return null;
@@ -45,7 +47,7 @@ class LegendItemButtonBBox extends PureComponent {
 
     return (
       <Tooltip
-        overlay="Fit to bounds"
+        overlay={tooltipText || 'Fit to bounds'}
         overlayClassName="c-rc-tooltip -default"
         placement="top"
         trigger={tooltipOpened ? '' : 'hover'}

--- a/src/components/legend/components/legend-item-toolbar/legend-item-button-info/index.js
+++ b/src/components/legend/components/legend-item-toolbar/legend-item-button-info/index.js
@@ -16,6 +16,7 @@ class LegendItemButtonInfo extends PureComponent {
     icon: PropTypes.string,
     focusStyle: PropTypes.object,
     defaultStyle: PropTypes.object,
+    tooltipText: PropTypes.string,
 
     // ACTIONS
     onChangeInfo: PropTypes.func
@@ -27,6 +28,7 @@ class LegendItemButtonInfo extends PureComponent {
     icon: '',
     focusStyle: {},
     defaultStyle: {},
+    tooltipText: '',
 
     onChangeInfo: () => {}
   }
@@ -36,12 +38,12 @@ class LegendItemButtonInfo extends PureComponent {
   }
 
   render() {
-    const { activeLayer, tooltipOpened, icon, focusStyle, defaultStyle } = this.props;
+    const { activeLayer, tooltipOpened, icon, focusStyle, defaultStyle, tooltipText } = this.props;
     const { visible } = this.state;
 
     return (
       <Tooltip
-        overlay="Layer info"
+        overlay={tooltipText || 'Layer info'}
         overlayClassName="c-rc-tooltip -default"
         placement="top"
         trigger={tooltipOpened ? '' : 'hover'}

--- a/src/components/legend/components/legend-item-toolbar/legend-item-button-layers/index.js
+++ b/src/components/legend/components/legend-item-toolbar/legend-item-button-layers/index.js
@@ -20,6 +20,7 @@ class LegendItemButtonLayers extends PureComponent {
     icon: PropTypes.string,
     focusStyle: PropTypes.object,
     defaultStyle: PropTypes.object,
+    tooltipText: PropTypes.string,
 
     onChangeLayer: PropTypes.func,
     onTooltipVisibilityChange: PropTypes.func
@@ -31,6 +32,7 @@ class LegendItemButtonLayers extends PureComponent {
     icon: '',
     focusStyle: {},
     defaultStyle: {},
+    tooltipText: '',
 
     onChangeLayer: () => {},
     onTooltipVisibilityChange: () => {}
@@ -74,7 +76,7 @@ class LegendItemButtonLayers extends PureComponent {
   }
 
   render() {
-    const { layers, activeLayer, icon, focusStyle, defaultStyle } = this.props;
+    const { layers, activeLayer, icon, focusStyle, defaultStyle, tooltipText } = this.props;
     const { visibilityClick, visibilityHover, multiLayersActive } = this.state;
     const timelineLayers = this.getTimelineLayers();
 
@@ -100,7 +102,7 @@ class LegendItemButtonLayers extends PureComponent {
 
         <Tooltip
           visibile={(!visibilityClick && visibilityHover) || multiLayersActive}
-          overlay={multiLayersActive ? `${layers.length} layers` : 'Layers'}
+          overlay={tooltipText || (multiLayersActive ? `${layers.length} layers` : 'Layers')}
           overlayClassName="c-rc-tooltip -default"
           placement="top"
           onVisibleChange={visibility => this.setState({ visibilityHover: visibility })}

--- a/src/components/legend/components/legend-item-toolbar/legend-item-button-opacity/index.js
+++ b/src/components/legend/components/legend-item-toolbar/legend-item-button-opacity/index.js
@@ -25,6 +25,7 @@ class LegendItemButtonOpacity extends PureComponent {
     defaultStyle: PropTypes.object,
     enabledStyle: PropTypes.object,
     disabledStyle: PropTypes.object,
+    tooltipText: PropTypes.string,
 
     onChangeOpacity: PropTypes.func,
     onTooltipVisibilityChange: PropTypes.func
@@ -41,6 +42,7 @@ class LegendItemButtonOpacity extends PureComponent {
     defaultStyle: {},
     enabledStyle: {},
     disabledStyle: {},
+    tooltipText: '',
 
     onChangeOpacity: () => {},
     onTooltipVisibilityChange: () => {}
@@ -69,6 +71,7 @@ class LegendItemButtonOpacity extends PureComponent {
       defaultStyle,
       disabledStyle,
       focusStyle,
+      tooltipText,
       ...rest
     } = this.props;
 
@@ -100,7 +103,7 @@ class LegendItemButtonOpacity extends PureComponent {
       >
         <Tooltip
           visible={visibilityHover && !visibilityClick && visibility}
-          overlay={`Opacity ${opacity ? `(${opacity})` : ''}`}
+          overlay={tooltipText || (`Opacity ${opacity ? `(${opacity * 100}%)` : ''}`)}
           overlayClassName="c-rc-tooltip -default"
           placement="top"
           onVisibleChange={v => this.setState({ visibilityHover: v })}

--- a/src/components/legend/components/legend-item-toolbar/legend-item-button-opacity/legend-item-button-opacity-tooltip/index.js
+++ b/src/components/legend/components/legend-item-toolbar/legend-item-button-opacity/legend-item-button-opacity-tooltip/index.js
@@ -42,8 +42,8 @@ class LegendOpacityTooltip extends React.Component {
         <div styleName="slider-tooltip-container">
           <Range
             marks={{
-              [min]: '0',
-              [max]: '1.00'
+              [min]: '0%',
+              [max]: '100%'
             }}
             min={min}
             max={max}

--- a/src/components/legend/components/legend-item-toolbar/legend-item-button-opacity/legend-item-button-opacity-tooltip/styles.scss
+++ b/src/components/legend/components/legend-item-toolbar/legend-item-button-opacity/legend-item-button-opacity-tooltip/styles.scss
@@ -4,3 +4,10 @@
     min-width: 150px;
   }
 }
+
+:global {
+  .rc-slider-mark {
+    width: 90%;
+    margin-left: 5%;
+  }
+}

--- a/src/components/legend/components/legend-item-toolbar/legend-item-button-remove/index.js
+++ b/src/components/legend/components/legend-item-toolbar/legend-item-button-remove/index.js
@@ -18,6 +18,7 @@ class LegendItemButtonRemove extends PureComponent {
     icon: PropTypes.string,
     focusStyle: PropTypes.object,
     defaultStyle: PropTypes.object,
+    tooltipText: PropTypes.string,
 
     // ACTIONS
     onRemoveLayer: PropTypes.func
@@ -29,6 +30,7 @@ class LegendItemButtonRemove extends PureComponent {
     icon: '',
     focusStyle: {},
     defaultStyle: {},
+    tooltipText: '',
 
     // ACTIONS
     onRemoveLayer: () => {}
@@ -39,12 +41,12 @@ class LegendItemButtonRemove extends PureComponent {
   }
 
   render() {
-    const { activeLayer, tooltipOpened, icon, focusStyle, defaultStyle } = this.props;
+    const { activeLayer, tooltipOpened, icon, focusStyle, defaultStyle, tooltipText } = this.props;
     const { visible } = this.state;
 
     return (
       <Tooltip
-        overlay="Remove"
+        overlay={tooltipText || 'Remove layer'}
         overlayClassName="c-rc-tooltip -default"
         placement="top"
         trigger={tooltipOpened ? '' : 'hover'}

--- a/src/components/legend/components/legend-item-toolbar/legend-item-button-visibility/index.js
+++ b/src/components/legend/components/legend-item-toolbar/legend-item-button-visibility/index.js
@@ -20,7 +20,8 @@ class LegendItemButtonVisibility extends PureComponent {
     iconShow: PropTypes.string,
     iconHide: PropTypes.string,
     focusStyle: PropTypes.object,
-    defaultStyle: PropTypes.object
+    defaultStyle: PropTypes.object,
+    tooltipText: PropTypes.string
   }
 
   static defaultProps = {
@@ -31,6 +32,7 @@ class LegendItemButtonVisibility extends PureComponent {
     iconHide: '',
     focusStyle: {},
     defaultStyle: {},
+    tooltipText: '',
 
     onChangeVisibility: () => {}
   }
@@ -40,7 +42,7 @@ class LegendItemButtonVisibility extends PureComponent {
   }
 
   render() {
-    const { activeLayer, visibility, tooltipOpened, iconShow, iconHide, focusStyle, defaultStyle } = this.props;
+    const { activeLayer, visibility, tooltipOpened, iconShow, iconHide, focusStyle, defaultStyle, tooltipText } = this.props;
     const { visible } = this.state;
 
     const showIcon = iconShow || 'icon-show';
@@ -49,7 +51,7 @@ class LegendItemButtonVisibility extends PureComponent {
 
     return (
       <Tooltip
-        overlay="Visibility"
+        overlay={tooltipText || (visibility ? 'Hide layer' : 'Show layer')}
         overlayClassName="c-rc-tooltip -default"
         placement="top"
         trigger={tooltipOpened ? '' : 'hover'}


### PR DESCRIPTION
This is a proposal for improved tooltips on the `LegendToolBar` components:

1. Update all tooltips to be consistent in their default labels with the use of layer consistently and update tooltip text based on state of layer. e.g. `visibility === 1 ? 'Hide layer' : 'Show layer'`.

2. Display opacity in %'s not float between 0 and 1. Easy to understand and looks better too.

3. Allow all tooltip texts to be over written by the parent application using the new `tooltipText` props.

4. Update styles on the `OpacityButton` component to make the slider more readable (and also use %'s).