### PR TITLE
Fix/round opacity percentage

### DIFF
--- a/src/components/legend/components/legend-item-toolbar/legend-item-button-opacity/index.js
+++ b/src/components/legend/components/legend-item-toolbar/legend-item-button-opacity/index.js
@@ -103,7 +103,7 @@ class LegendItemButtonOpacity extends PureComponent {
       >
         <Tooltip
           visible={visibilityHover && !visibilityClick && visibility}
-          overlay={tooltipText || (`Opacity ${opacity ? `(${opacity * 100}%)` : ''}`)}
+          overlay={tooltipText || (`Opacity ${opacity ? `(${Math.round(opacity * 100)}%)` : ''}`)}
           overlayClassName="c-rc-tooltip -default"
           placement="top"
           onVisibleChange={v => this.setState({ visibilityHover: v })}


### PR DESCRIPTION
The opacity was displaying as `57.777777%` for example in some cases. This was less than ideal. Possibly because opacity only identifies as a float. Now it is always a float 🤽‍♂️ .