### PR TITLE
Fix/remove parent props spread on all LegendListItem children

### DIFF
--- a/src/components/legend/components/legend-list-item/index.js
+++ b/src/components/legend/components/legend-list-item/index.js
@@ -56,7 +56,7 @@ class LegendListItem extends PureComponent {
             </header>
 
             {React.Children.map(children, child => (React.isValidElement(child) && typeof child.type !== 'string' ?
-              React.cloneElement(child, { ...props, layers, activeLayer })
+              React.cloneElement(child, { layers, activeLayer })
               :
               child
             ))}


### PR DESCRIPTION
Due to the parent props being spread on all children of the `LegendListItem` component, any change in layerGroups within my app causes everything to re render. This is not ideal.

As we are using LegendListItem as a parent with children any props required can be passed to children manually.