### PR TITLE
Fix/align gradients correctly

### DIFF
--- a/src/components/legend/components/legend-item-types/legend-item-type-gradient/index.js
+++ b/src/components/legend/components/legend-item-types/legend-item-type-gradient/index.js
@@ -43,13 +43,13 @@ class LegendTypeGradient extends PureComponent {
           />
         </div>
         <ul>
-          {legendConfig.items.map(({ name, color, value }) => (
+          {legendConfig.items.map(({ name, color, value }) => name || value ? (
             <li key={`legend-gradient-item-${color}-${value}-${name}`}>
               <span styleName="name">
                 {name || value}
               </span>
             </li>
-          ))}
+          ) : null)}
         </ul>
       </div>
     );

--- a/src/components/legend/components/legend-item-types/legend-item-type-gradient/styles.scss
+++ b/src/components/legend/components/legend-item-types/legend-item-type-gradient/styles.scss
@@ -15,13 +15,27 @@
     &:before {
       content: none !important; // For the NexGDDP tool
     }
+
+    .name {
+      display: block;
+      font-family: inherit;
+      text-align: center;
+    }
+
+    &:first-child {
+      .name {
+        text-align: left;
+      }
+    }
+
+    &:last-child {
+      .name {
+        text-align: right;
+      }
+    }
   }
 
-  .name {
-    display: block;
-    font-family: 'Helvetica Neue', Arial, sans-serif;
-    text-align: center;
-  }
+
 
   .legend-gradient-icon {
     display: flex;


### PR DESCRIPTION
This addresses the alignment of legend texts in the <LegendItemTypes /> gradient component.

Before the Legend was painting empty values as `<span>` and aligning all values to the center of the `<span>`. Now the first and last children are aligned left and right respectively, and the rest to the center. This fixes issues with null legend config also.

Before:
![screen shot 2018-09-10 at 10 23 54](https://user-images.githubusercontent.com/20288774/45285526-a5616700-b4e3-11e8-9f68-2e1c2e580396.png)

After: 
![screen shot 2018-09-10 at 10 23 37](https://user-images.githubusercontent.com/20288774/45285530-a98d8480-b4e3-11e8-88ab-7a6b04c0901f.png)
