### PR TITLE
Fix: layers tooltip fixed

### DIFF
--- a/src/components/legend/components/legend-item-toolbar/legend-item-button-layers/index.js
+++ b/src/components/legend/components/legend-item-toolbar/legend-item-button-layers/index.js
@@ -42,9 +42,10 @@ class LegendItemButtonLayers extends PureComponent {
   }
 
   componentWillReceiveProps(nextProps) {
-    const { scrolling, i } = nextProps;
+    const { scrolling, i: prevIndex } = this.props;
+    const { i: nextIndex } = nextProps;
 
-    if (scrolling || i) {
+    if (scrolling || prevIndex !== nextIndex) {
       this.onTooltipVisibilityChange(false);
     }
   }
@@ -110,7 +111,7 @@ class LegendItemButtonLayers extends PureComponent {
       >
         <Tooltip
           visible={multiLayersActive || (!visibilityClick && visibilityHover)}
-          overlay={tooltipText || (multiLayersActive ? `${layers.length} layers` : 'Layers')}
+          overlay={tooltipText || `${layers.length} layers`}
           overlayClassName="c-rc-tooltip -default"
           placement="top"
           trigger={tooltipOpened ? '' : 'hover'}

--- a/src/components/legend/components/legend-list/index.js
+++ b/src/components/legend/components/legend-list/index.js
@@ -23,7 +23,11 @@ class LegendList extends PureComponent {
     this.timeout = null;
   }
 
-  onScroll = () => {
+  onScroll = (e) => {
+    if (e.target.id !== 'wri-legend-list') {
+      return false;
+    }
+
     const { scrolling } = this.state;
     if (this.timeout) {
       // if there is already a timeout in process cancel it
@@ -50,7 +54,7 @@ class LegendList extends PureComponent {
     const { scrolling } = this.state;
 
     return (
-      <ul styleName="c-legend-list" onScroll={this.onScroll}>
+      <ul id="wri-legend-list" styleName="c-legend-list" onScroll={this.onScroll}>
         {React.Children.map(children, (child, index) =>
           React.cloneElement(child, {
             sortable,

--- a/src/components/tooltip/styles.scss
+++ b/src/components/tooltip/styles.scss
@@ -136,7 +136,7 @@
   	//Instead of the line below you could use @include border-radius($radius, $vertical-radius)
   	border-radius: 0;
   	min-height: 34px;
-  	border: 0;
+		border: 0;
   }
 
   .rc-tooltip-arrow {
@@ -365,7 +365,9 @@
         border: 1px solid rgba($border-color-1, 0.15);
         border-radius: 4px;
         box-shadow: 0 20px 30px 0 rgba($color-black, 0.1);
-        font-size: $font-size-small;
+				font-size: $font-size-small;
+				max-height: 400px;
+				overflow: auto;
       }
 
       &.rc-tooltip-placement-top .rc-tooltip-arrow {


### PR DESCRIPTION
## Overview
This PR fixes the layers tooltip.
- If they were in other position than 0 it was impossible to show them
- onScroll only affects to the `wri-legend-list` div