### PR TITLE
Adds tooltip to timeline

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "layer-manager": "^1.10.0",
     "lodash": "^4.17.10",
     "prop-types": "^15.6.2",
-    "rc-slider": "^8.6.1",
+    "rc-slider": "^8.6.3",
     "rc-tooltip": "3.7.0",
     "react-sortable-hoc": "^0.6.8",
     "react-vega": "^4.0.2",

--- a/src/components/form/range/index.js
+++ b/src/components/form/range/index.js
@@ -21,6 +21,7 @@ class Range extends PureComponent {
 
   render() {
     const { value } = this.state;
+
     return (
       <Slider
         trackStyle={[

--- a/src/components/form/range/styles.scss
+++ b/src/components/form/range/styles.scss
@@ -45,26 +45,21 @@
     cursor: -webkit-grab;
     cursor: grab;
     border-radius: 50%;
-    border: solid 2px #96dbfa;
     background-color: #fff;
     -ms-touch-action: pan-x;
     touch-action: pan-x;
   }
 
-  .rc-slider-handle:hover {
-    border-color: #57c5f7;
+
+  .rc-slider-handle:focus,
+  .rc-slider-handle:active {
+    outline: none;
+    box-shadow: none;
   }
 
   .rc-slider-handle:active {
-    border-color: #57c5f7;
-    box-shadow: 0 0 5px #57c5f7;
     cursor: -webkit-grabbing;
     cursor: grabbing;
-    outline: none;
-  }
-
-  .rc-slider-handle:focus {
-    outline: none;
   }
 
   .rc-slider-mark {

--- a/src/components/form/range/styles.scss
+++ b/src/components/form/range/styles.scss
@@ -64,8 +64,6 @@
   }
 
   .rc-slider-handle:focus {
-    border-color: #57c5f7;
-    box-shadow: 0 0 0 5px #96dbfa;
     outline: none;
   }
 
@@ -95,6 +93,7 @@
     width: 100%;
     height: 4px;
     background: transparent;
+    cursor: pointer;
   }
 
   .rc-slider-dot {

--- a/src/components/legend/components/legend-item-timeline/index.js
+++ b/src/components/legend/components/legend-item-timeline/index.js
@@ -116,6 +116,18 @@ class LegendItemTimeline extends PureComponent {
     // Return null if timeline doesn not exist
     if (!timelineLayers.length) return null;
 
+    const timelineMarks = {};
+
+    timelineLayers.forEach((val, index) => {
+      const isVisible = (index === 0  || index === timelineLayers.length - 1);
+      timelineMarks[val.layerConfig.timelineLabel] =  {
+        label: val.layerConfig.timelineLabel,
+        style: {
+          visibility: isVisible ? 'visible' : 'hidden'
+        }
+      }
+    });
+
     const first = timelineLayers[0].layerConfig.order;
     const last = timelineLayers[timelineLayers.length - 1].layerConfig.order;
 
@@ -148,15 +160,11 @@ class LegendItemTimeline extends PureComponent {
         <Range
           min={first}
           max={last}
+          step={null}
           handle={this.renderHandle}
-          marks={[first, last].reduce((acc, val) =>
-            ({ ...acc, [val]: val })
-          , {} )}
-          value={step || first}
-          onAfterChange={(nextStep) => {
-            this.setState({ step: nextStep });
-            this.setStep(nextStep);
-          }}
+          marks={timelineMarks}
+          defaultValue={step || first}
+          onAfterChange={(nextStep) => { this.setStep(nextStep); }}
         />
       </div>
     );

--- a/src/components/legend/components/legend-item-timeline/index.js
+++ b/src/components/legend/components/legend-item-timeline/index.js
@@ -11,14 +11,19 @@ import './styles.scss';
 
 class LegendItemTimeline extends PureComponent {
   static propTypes = {
-    value: PropTypes.string.isRequired,
-    dragging: PropTypes.bool.isRequired,
-    index: PropTypes.number.isRequired,
+    value: PropTypes.number,
+    dragging: PropTypes.bool,
+    index: PropTypes.number,
     layers: PropTypes.array,
     onChangeLayer: PropTypes.func.isRequired
   }
 
-  static defaultProps = { layers: [] }
+  static defaultProps = {
+    layers: [],
+    value: 0,
+    dragging: false,
+    index: 0
+  }
 
   state = {
     step: null,

--- a/src/components/legend/components/legend-item-timeline/index.js
+++ b/src/components/legend/components/legend-item-timeline/index.js
@@ -93,9 +93,9 @@ class LegendItemTimeline extends PureComponent {
 
     return (
       <Tooltip
-        overlayClassName="c-rc-tooltip -default -timeline"
+        overlayClassName="c-rc-tooltip -default"
         overlay={value}
-        visible
+        visible={dragging}
         placement="top"
         key={index}
       >

--- a/src/components/legend/components/legend-item-timeline/index.js
+++ b/src/components/legend/components/legend-item-timeline/index.js
@@ -3,20 +3,22 @@ import PropTypes from 'prop-types';
 import debounce from 'lodash/debounce';
 import sortBy from 'lodash/sortBy';
 import Range from 'components/form/range';
+import Tooltip from 'components/tooltip';
+import Slider from 'rc-slider';
 
 // Styles
 import './styles.scss';
 
 class LegendItemTimeline extends PureComponent {
   static propTypes = {
+    value: PropTypes.string.isRequired,
+    dragging: PropTypes.bool.isRequired,
+    index: PropTypes.number.isRequired,
     layers: PropTypes.array,
     onChangeLayer: PropTypes.func.isRequired
   }
 
-  static defaultProps = {
-    // defaultProps
-    layers: []
-  }
+  static defaultProps = { layers: [] }
 
   state = {
     step: null,
@@ -85,14 +87,29 @@ class LegendItemTimeline extends PureComponent {
     if (currentLayer) onChangeLayer(currentLayer);
   }, 500)
 
+  renderHandle = (props) => {
+    const { value, dragging, index, ...restProps } = props;
+    const { Handle } = Slider;
+
+    return (
+      <Tooltip
+        overlayClassName="c-rc-tooltip -default -timeline"
+        overlay={value}
+        visible
+        placement="top"
+        key={index}
+      >
+        <Handle value={value} {...restProps} />
+      </Tooltip>
+    );
+  };
+
   render() {
     const { step } = this.state;
     const timelineLayers = this.getTimelineLayers();
 
     // Return null if timeline doesn not exist
-    if (!timelineLayers.length) {
-      return null;
-    }
+    if (!timelineLayers.length) return null;
 
     const first = timelineLayers[0].layerConfig.order;
     const last = timelineLayers[timelineLayers.length - 1].layerConfig.order;
@@ -123,20 +140,19 @@ class LegendItemTimeline extends PureComponent {
           </button>
         } */}
 
-        {!!timelineLayers.length && (
-          <Range
-            min={first}
-            max={last}
-            marks={timelineLayers.reduce((acc, val) =>
-              ({ ...acc, [val.layerConfig.timelineLabel]: val.layerConfig.timelineLabel })
-            , {} )}
-            value={step || first}
-            onAfterChange={(nextStep) => {
-              this.setState({ step: nextStep });
-              this.setStep(nextStep);
-            }}
-          />
-        )}
+        <Range
+          min={first}
+          max={last}
+          handle={this.renderHandle}
+          marks={[first, last].reduce((acc, val) =>
+            ({ ...acc, [val]: val })
+          , {} )}
+          value={step || first}
+          onAfterChange={(nextStep) => {
+            this.setState({ step: nextStep });
+            this.setStep(nextStep);
+          }}
+        />
       </div>
     );
   }

--- a/src/components/legend/components/legend-item-timeline/styles.scss
+++ b/src/components/legend/components/legend-item-timeline/styles.scss
@@ -2,7 +2,7 @@
 
 .c-legend-timeline {
   display: flex;
-  margin: $space-1 * 3 $space-1 * 3 $space-1 * 2 0;
+  margin: $space-1 * 5 $space-1 * 3 $space-1 * 2 0;
 
   > button {
     padding: 0;

--- a/src/components/tooltip/styles.scss
+++ b/src/components/tooltip/styles.scss
@@ -365,7 +365,8 @@
         border: 1px solid rgba($border-color-1, 0.15);
         border-radius: 4px;
         box-shadow: 0 20px 30px 0 rgba($color-black, 0.1);
-				font-size: $font-size-small;
+        font-size: $font-size-small;
+        min-height: auto;
 				max-height: 400px;
 				overflow: auto;
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7113,9 +7113,9 @@ rc-animate@2.x:
     css-animation "^1.3.2"
     prop-types "15.x"
 
-rc-slider@^8.6.1:
-  version "8.6.1"
-  resolved "https://registry.yarnpkg.com/rc-slider/-/rc-slider-8.6.1.tgz#ee5e0380dbdf4b5de6955a265b0d4ff6196405d1"
+rc-slider@^8.6.3:
+  version "8.6.3"
+  resolved "https://registry.yarnpkg.com/rc-slider/-/rc-slider-8.6.3.tgz#1ca0e0bd2863252741de75e7bf8c9f2cfcffccb7"
   dependencies:
     babel-runtime "6.x"
     classnames "^2.2.5"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/999124/46162329-2f515400-c288-11e8-926d-8b11d65f78fd.png)

## Overview
Adds tooltip with the current value. Also, omits marks but first and last on.

This a **temporary** workaround until we develop the new timelines.

Merge https://github.com/resource-watch/resource-watch/pull/831 after merge this, please.

## Testing instructions
Check http://localhost:9000/data/explore?zoom=3&lat=0&lng=0&basemap=dark&labels=light&layers=%255B%257B%2522dataset%2522%253A%2522c0c71e67-0088-4d69-b375-85297f79ee75%2522%252C%2522opacity%2522%253A1%252C%2522layer%2522%253A%2522bee905be-cb07-411c-b646-df7cb0a247da%2522%257D%255D&page=1&sort=most-viewed&sortDirection=-1

## Pivotal task
https://www.pivotaltracker.com/story/show/160817619
