### PR TITLE
Enables widget tooltip by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "rc-tooltip": "3.7.0",
     "react-sortable-hoc": "^0.6.8",
     "react-vega": "^4.0.2",
+    "vega-tooltip": "^0.13.0",
     "wri-json-api-serializer": "^1.0.1"
   },
   "peerDependencies": {

--- a/src/components/widgets/vega-chart/index.js
+++ b/src/components/widgets/vega-chart/index.js
@@ -1,6 +1,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { parse, changeset, View } from 'vega-lib';
+import vegaTooltip from 'vega-tooltip';
 import { capitalize, isDefined, isFunction } from './utils';
 
 // Opimized resize
@@ -32,7 +33,7 @@ const propTypes = {
   logLevel: PropTypes.number,
   width: PropTypes.number,
   height: PropTypes.number,
-  tooltip: PropTypes.func,
+  tooltip: PropTypes.bool,
   background: PropTypes.string,
   padding: PropTypes.object,
   renderer: PropTypes.string,
@@ -46,6 +47,7 @@ const propTypes = {
 
 const defaultProps = {
   className: '',
+  tooltip: true,
   renderer: 'svg',
   enableHover: true,
   onNewView() {},
@@ -204,7 +206,6 @@ class Vega extends PureComponent {
         [
           'logLevel',
           'renderer',
-          'tooltip',
           'background',
           'width',
           'height',
@@ -232,9 +233,11 @@ class Vega extends PureComponent {
               this.updateData(d.name, props.data[d.name]);
             });
         }
-        if (props.enableHover) {
-          view.hover();
-        }
+
+        if (props.enableHover) view.hover();
+
+        if (props.tooltip) vegaTooltip(view);
+
         view.run();
 
         props.onNewView(view);

--- a/yarn.lock
+++ b/yarn.lock
@@ -6459,10 +6459,6 @@ mime@^1.5.0:
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
 
-mime@^2.0.3:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/mime/-/mime-2.3.1.tgz#b1621c54d63b97c47d3cfe7f7215f7d64517c369"
-
 mimic-fn@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
@@ -10287,14 +10283,6 @@ urix@^0.1.0, urix@~0.1.0:
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
 
-url-loader@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/url-loader/-/url-loader-1.1.2.tgz#b971d191b83af693c5e3fea4064be9e1f2d7f8d8"
-  dependencies:
-    loader-utils "^1.1.0"
-    mime "^2.0.3"
-    schema-utils "^1.0.0"
-
 url-parse@1.0.x:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.0.5.tgz#0854860422afdcfefeb6c965c662d4800169927b"
@@ -10554,6 +10542,13 @@ vega-statistics@^1.2.1:
   integrity sha512-70CC6rbS1RFVEpKT/qOGHhHATeh92cB2gXnjg+zErrY8255cBlOW8X0s4iZBsoa4vibGXb42imyM+rxAwL1VPA==
   dependencies:
     d3-array "1"
+
+vega-tooltip@^0.13.0:
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/vega-tooltip/-/vega-tooltip-0.13.0.tgz#008d06a1c8f94ba3f23f52bb2498661b21dbf5e6"
+  integrity sha512-NbeHzpxwKZ+yk+CION3wRH66rx9XGx5v6M82LT6qSIAnUrH8eh+sFtjK6pO7ErXGF5AieAhg8Hfb/NvC8uNMuA==
+  dependencies:
+    vega-util "^1.7.0"
 
 vega-transforms@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/999124/47507212-0b2a6800-d872-11e8-9278-786721d441ed.png)



## Overview
Adds a basic `vega-tooltip` implementation to Vega charts. It's optional, by default will be enabled.