### PR TITLE
Feat: adds support to leaflet as a node module

### DIFF
--- a/src/components/map/index.js
+++ b/src/components/map/index.js
@@ -5,9 +5,28 @@ import isEqual from 'lodash/isEqual';
 import './styles.scss';
 
 class Maps extends Component {
-  events = {};
+  static L = (typeof window !== 'undefined') ? window.L : undefined;
 
-  static L = (typeof window !== 'undefined') && window.L;
+  static patchLeaflet() {
+    /*
+     * Workaround for 1px lines appearing in some browsers due to fractional transforms
+     * and resulting anti-aliasing.
+     * https://github.com/Leaflet/Leaflet/issues/3575
+     */
+    /* eslint-disable */
+    const originalInitTile = Maps.L && Maps.L.GridLayer.prototype._initTile;
+    Maps.L && Maps.L.GridLayer.include({
+      _initTile(tile) {
+        originalInitTile.call(this, tile);
+        const tileSize = this.getTileSize();
+        tile.style.width = `${tileSize.x + 1  }px`;
+        tile.style.height = `${tileSize.y + 1  }px`;
+      }
+    });
+    /* eslint-enable */
+  }
+
+  events = {};
 
   static propTypes = {
     /** A function that returns the map instance */
@@ -80,23 +99,6 @@ class Maps extends Component {
     interactionEnabled: true,
     scrollZoomEnabled: true,
     onReady: () => {}
-  }
-
-  static patchLeaflet() {
-  /*
-   * Workaround for 1px lines appearing in some browsers due to fractional transforms
-   * and resulting anti-aliasing.
-   * https://github.com/Leaflet/Leaflet/issues/3575
-   */
-    const originalInitTile = Maps.L && Maps.L.GridLayer.prototype._initTile;
-    Maps.L && Maps.L.GridLayer.include({
-      _initTile(tile) {
-        originalInitTile.call(this, tile);
-        const tileSize = this.getTileSize();
-        tile.style.width = `${tileSize.x + 1  }px`;
-        tile.style.height = `${tileSize.y + 1  }px`;
-      }
-    });
   }
 
   constructor(props) {

--- a/src/components/map/map-popup/index.js
+++ b/src/components/map/map-popup/index.js
@@ -4,9 +4,10 @@ import { render } from 'react-dom';
 
 import isEqual from 'lodash/isEqual';
 
-const { L } = (typeof window !== 'undefined') ? window : {};
 
 export class MapPopup extends Component {
+  static L = (typeof window !== 'undefined') ? window.L : undefined;
+
   static propTypes = {
     children: PropTypes.node.isRequired,
     /** Map instance */
@@ -28,16 +29,17 @@ export class MapPopup extends Component {
   }
 
   componentDidMount() {
-    if (typeof L === 'undefined') {
+    if (typeof MapPopup.L === 'undefined') {
       return;
     }
+    const { onReady } = this.props;
 
-    this.popup = this.popup || L.popup({
+    this.popup = this.popup || MapPopup.L.popup({
       maxWidth: 400,
       minWidth: 240
     });
 
-    this.props.onReady(this.popup);
+    onReady(this.popup);
   }
 
   componentDidUpdate(prevProps) {


### PR DESCRIPTION
## Overview
Adds support for using Leaflet as a Node Module in the `<Maps />` and `<MapPopUp />` components.

## Testing instructions
```js
import L from 'leaflet';
import Maps from 'wri-api-components/dist/map';

Maps.L = L;

**Use Maps...**
```

---

## Checklist before submitting
[x] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
[x] Meaningful commits and code rebased on `develop`.
[ ] Update the changelog (see below)

