### PR TITLE
Rename WRI leftovers

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -22,7 +22,7 @@
     [
       "react-css-modules",
       {
-        "generateScopedName": "wri_api__[local]",
+        "generateScopedName": "vizzuality__[local]",
         "filetypes": {
           ".scss": {
             "syntax": "postcss-scss"

--- a/.buildrc.json
+++ b/.buildrc.json
@@ -1,7 +1,7 @@
 {
   "srcDir": "src/components",
   "mainModuleFileName": "bundle.js",
-  "mainModuleName": "WRIAPIComponents",
+  "mainModuleName": "VizzualityComponents",
   "fileExtensions": [".js"],
   "exclude": [],
   "include": ["*"],

--- a/src/components/form/range/index.js
+++ b/src/components/form/range/index.js
@@ -74,7 +74,7 @@ class Range extends PureComponent {
         handle={this.renderHandle}
         value={value}
         onChange={v => this.setState({ value: v })}
-        className="wri_api__slider-range"
+        className="vizzuality__slider-range"
       />
     );
   }

--- a/src/components/legend/components/legend-item-timestep/component.js
+++ b/src/components/legend/components/legend-item-timestep/component.js
@@ -70,8 +70,8 @@ class Timeline extends PureComponent {
 
     const externalClass = classnames({ [customClass]: !!customClass });
     const sliderClass = classnames(
-      'wri_api__range',
-      { 'wri_api__can-play': canPlay }
+      'vizzuality__range',
+      { 'vizzuality__can-play': canPlay }
     );
     const iconStatus = classnames({
       'icon-pause2': isPlaying,
@@ -95,7 +95,7 @@ class Timeline extends PureComponent {
           )}
           <Slider
             range
-            className="wri_api__slider-timestep"
+            className="vizzuality__slider-timestep"
             customClass={sliderClass}
             marks={marks}
             disabled={isPlaying}

--- a/src/components/slider/styles.scss
+++ b/src/components/slider/styles.scss
@@ -5,7 +5,7 @@
 // in your component styles file.
 
 // Please, do NOT touch these styles unless you want to modify
-// the styles for all sliders/ranges of WRI-API components.
+// the styles for all sliders/ranges of Vizzuality-API components.
 
 @import 'settings';
 

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -6,7 +6,7 @@ const webpackConfig = require('./styleguide.webpack.js');
 const { name, version } = require('./package.json');
 
 module.exports = {
-  title: `WRI components | ${version}`,
+  title: `Vizzuality components | ${version}`,
   template: {
     head: {
       links: [{

--- a/styleguide.webpack.js
+++ b/styleguide.webpack.js
@@ -35,7 +35,7 @@ module.exports = {
             options: {
               modules: true,
               importLoaders: 1,
-              localIdentName: 'wri_api__[local]'
+              localIdentName: 'vizzuality__[local]'
             }
           },
           {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -76,7 +76,7 @@ const config = {
             options: {
               modules: true,
               importLoaders: 1,
-              localIdentName: 'wri_api__[local]'
+              localIdentName: 'vizzuality__[local]'
             }
           },
           'postcss-loader',


### PR DESCRIPTION
## Overview
Remove last WRI leftovers. This is a breaking change, because I imagine some of our apps just override some styles. Now they need to change `wri_api` to `vizzuality`