### PR TITLE
Changes way to calculate timeline default value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.0.1] [Unreleased]
+- Changes way to calculate timeline default value [[code]](https://github.com/Vizzuality/vizzuality-components/pull/53/commits/6c9fa5113c0e4dc5e3522a4ac004de9479bb5e78)
 
 
 ## [1.0.0] - 2019-05-11
+CHANGELOG beginning.
+
 

--- a/src/components/form/range/index.js
+++ b/src/components/form/range/index.js
@@ -8,7 +8,6 @@ import Tooltip from 'components/tooltip';
 const RangeRender = createSliderWithTooltip(Slider.Range);
 
 class Range extends PureComponent {
-
   static propTypes = {
     value: PropTypes.oneOfType([
       PropTypes.number,
@@ -17,6 +16,9 @@ class Range extends PureComponent {
     range: PropTypes.bool,
     trackStyle: PropTypes.array,
     handleStyle: PropTypes.array,
+    railStyle: PropTypes.object,
+    dotStyle: PropTypes.object,
+    activeDotStyle: PropTypes.object,
     showTooltip: PropTypes.func,
     formatValue: PropTypes.func
   };
@@ -26,13 +28,16 @@ class Range extends PureComponent {
     range: false,
     showTooltip: null,
     formatValue: null,
+    railStyle: null,
     trackStyle: [
       { backgroundColor: '#c32d7b' },
       { backgroundColor: 'grey' }
     ],
     handleStyle: [
       { backgroundColor: '#c32d7b', width: '14px', height: '14px', border: 0 }
-    ]
+    ],
+    dotStyle: { display: 'none' },
+    activeDotStyle: { display: 'none' }
   };
 
   constructor(props) {
@@ -70,8 +75,6 @@ class Range extends PureComponent {
 
     return (
       <Component
-        activeDotStyle={{ display: 'none' }}
-        dotStyle={{ display: 'none' }}
         {...this.props}
         handle={this.renderHandle}
         value={value}

--- a/src/components/form/range/index.js
+++ b/src/components/form/range/index.js
@@ -15,6 +15,8 @@ class Range extends PureComponent {
       PropTypes.array
     ]),
     range: PropTypes.bool,
+    trackStyle: PropTypes.array,
+    handleStyle: PropTypes.array,
     showTooltip: PropTypes.func,
     formatValue: PropTypes.func
   };
@@ -23,7 +25,14 @@ class Range extends PureComponent {
     value: 0,
     range: false,
     showTooltip: null,
-    formatValue: null
+    formatValue: null,
+    trackStyle: [
+      { backgroundColor: '#c32d7b' },
+      { backgroundColor: 'grey' }
+    ],
+    handleStyle: [
+      { backgroundColor: '#c32d7b', width: '14px', height: '14px', border: 0 }
+    ]
   };
 
   constructor(props) {
@@ -61,13 +70,6 @@ class Range extends PureComponent {
 
     return (
       <Component
-        trackStyle={[
-          { backgroundColor: '#c32d7b' },
-          { backgroundColor: 'grey' }
-        ]}
-        handleStyle={[
-          { backgroundColor: '#c32d7b', width: '14px', height: '14px', border: 0 }
-        ]}
         activeDotStyle={{ display: 'none' }}
         dotStyle={{ display: 'none' }}
         {...this.props}

--- a/src/components/legend/components/legend-item-timeline/index.js
+++ b/src/components/legend/components/legend-item-timeline/index.js
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import classnames from 'classnames';
 import debounce from 'lodash/debounce';
 import sortBy from 'lodash/sortBy';
 import Range from 'components/form/range';
@@ -14,9 +15,14 @@ class LegendItemTimeline extends PureComponent {
     value: PropTypes.number,
     dragging: PropTypes.bool,
     index: PropTypes.number,
+    customClass: PropTypes.string,
     layers: PropTypes.array,
     trackStyle: PropTypes.array,
     handleStyle: PropTypes.array,
+    railStyle: PropTypes.object,
+    dotStyle: PropTypes.object,
+    activeDotStyle: PropTypes.object,
+    markStyle: PropTypes.object,
     onChangeLayer: PropTypes.func.isRequired
   }
 
@@ -25,8 +31,13 @@ class LegendItemTimeline extends PureComponent {
     value: 0,
     dragging: false,
     index: 0,
+    customClass: null,
     trackStyle: null,
-    handleStyle: null
+    handleStyle: null,
+    railStyle: null,
+    dotStyle: null,
+    activeDotStyle: null,
+    markStyle: {}
   }
 
   state = {
@@ -114,8 +125,17 @@ class LegendItemTimeline extends PureComponent {
   };
 
   render() {
-    const { trackStyle, handleStyle } = this.props;
+    const {
+      trackStyle,
+      handleStyle,
+      railStyle,
+      dotStyle,
+      activeDotStyle,
+      markStyle,
+      customClass
+    } = this.props;
     const { step } = this.state;
+    const externalClass = classnames({ [customClass]: !!customClass });
     const timelineLayers = this.getTimelineLayers();
 
     // Return null if timeline doesn not exist
@@ -128,6 +148,7 @@ class LegendItemTimeline extends PureComponent {
       timelineMarks[val.layerConfig.timelineLabel] =  {
         label: val.layerConfig.timelineLabel,
         style: {
+          ...markStyle,
           visibility: isVisible ? 'visible' : 'hidden'
         }
       }
@@ -139,7 +160,10 @@ class LegendItemTimeline extends PureComponent {
     const defaultValue = activeLayer ? activeLayer.layerConfig.order : first;
 
     return (
-      <div styleName="c-legend-timeline">
+      <div
+        styleName="c-legend-timeline"
+        className={externalClass}
+      >
         {/* {this.state.isPlaying &&
           <button
             styleName="timeline-play-button"
@@ -174,7 +198,10 @@ class LegendItemTimeline extends PureComponent {
           value={step || defaultValue}
           onAfterChange={(nextStep) => { this.setStep(nextStep); }}
           {...trackStyle && { trackStyle }}
+          {...railStyle && { railStyle }}
           {...handleStyle && { handleStyle }}
+          {...dotStyle && { dotStyle }}
+          {...activeDotStyle && { activeDotStyle }}
         />
       </div>
     );

--- a/src/components/legend/components/legend-item-timeline/index.js
+++ b/src/components/legend/components/legend-item-timeline/index.js
@@ -15,6 +15,8 @@ class LegendItemTimeline extends PureComponent {
     dragging: PropTypes.bool,
     index: PropTypes.number,
     layers: PropTypes.array,
+    trackStyle: PropTypes.array,
+    handleStyle: PropTypes.array,
     onChangeLayer: PropTypes.func.isRequired
   }
 
@@ -22,7 +24,9 @@ class LegendItemTimeline extends PureComponent {
     layers: [],
     value: 0,
     dragging: false,
-    index: 0
+    index: 0,
+    trackStyle: null,
+    handleStyle: null
   }
 
   state = {
@@ -110,6 +114,7 @@ class LegendItemTimeline extends PureComponent {
   };
 
   render() {
+    const { trackStyle, handleStyle } = this.props;
     const { step } = this.state;
     const timelineLayers = this.getTimelineLayers();
 
@@ -130,6 +135,8 @@ class LegendItemTimeline extends PureComponent {
 
     const first = timelineLayers[0].layerConfig.order;
     const last = timelineLayers[timelineLayers.length - 1].layerConfig.order;
+    const activeLayer = timelineLayers.find(_layer => _layer.active);
+    const defaultValue = activeLayer ? activeLayer.layerConfig.order : first;
 
     return (
       <div styleName="c-legend-timeline">
@@ -163,8 +170,11 @@ class LegendItemTimeline extends PureComponent {
           step={null}
           handle={this.renderHandle}
           marks={timelineMarks}
-          defaultValue={step || first}
+          defaultValue={defaultValue}
+          value={step || defaultValue}
           onAfterChange={(nextStep) => { this.setStep(nextStep); }}
+          {...trackStyle && { trackStyle }}
+          {...handleStyle && { handleStyle }}
         />
       </div>
     );


### PR DESCRIPTION
## Overview
- Modifies way to calculate default value based on the active layer. Otherwise, it will fall back in the first layer.
- Enables passing custom styles.

## Testing instructions
You can test it with a dataset with several layers with timeline config like: https://api.resourcewatch.org/v1/dataset/595bcf6f-0343-4146-ba0d-c54b1c928510?application=rw&env=production,preproduction&language=en&includes=layer

## Pivotal task
–

---

## Checklist before submitting
[ ] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
[ ] Meaningful commits and code rebased on `develop`.
[ ] Update the changelog (see below)

## Changelog

If not already done, add a new entry in the changelog with the new version number and "not yet released". For example, if the current version of the editor is v0.0.1 and your PR is the first for the new version, add:
```md
### v0.0.2 (not yet released)
```

and below, the bullets with the changes of your PR:
```
- Fix a bug preventing the editor from XXX
```

