### PR TITLE
Prevents map popup to update without latLng

### DIFF
--- a/src/components/map/map-popup/index.js
+++ b/src/components/map/map-popup/index.js
@@ -55,7 +55,7 @@ export class MapPopup extends Component {
       this.setPopup();
     }
 
-    if (!isEqual(prevData, nextData)) {
+    if (!isEqual(prevData, nextData) && prevLatLng) {
       this.updatePopup();
     }
   }


### PR DESCRIPTION
## Overview
Prevents map popup initalize without latLng

---

## Checklist before submitting
[ ] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
[ ] Meaningful commits and code rebased on `develop`.
[ ] Update the changelog (see below)

## Changelog

If not already done, add a new entry in the changelog with the new version number and "not yet released". For example, if the current version of the editor is v0.0.1 and your PR is the first for the new version, add:
```md
### v0.0.2 (not yet released)
```

and below, the bullets with the changes of your PR:
```
- Fix a bug preventing the editor from XXX
```

