### PR TITLE
Add timestep as a separate module.

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,7 +27,8 @@ const config = {
     bundle: path.resolve(__dirname, 'src/components/index.js'),
     spinner: path.resolve(__dirname, 'src/components/spinner/index.js'),
     // datepicker: path.resolve(__dirname, 'src/components/datepicker/index.js'),
-    slider: path.resolve(__dirname, 'src/components/slider/index.js')
+    slider: path.resolve(__dirname, 'src/components/slider/index.js'),
+    timestep: path.resolve(__dirname, 'src/components/timestep/index.js')
   },
 
   output: {


### PR DESCRIPTION
## Overview
There's no dedicated webpack entry to the timestep component, which forces us to install `vega-lib` 🙄 .

## Testing instructions
Build the project and import the timestep component

## Grumpy comments
`vega-lib` really? Why not have a single dedicated export for the vega chart and exclude it from the main export.
