### PR TITLE
Fix/return correct endDate and trimEndDate in legend time step

### DIFF
--- a/src/components/legend/components/legend-item-timestep/index.js
+++ b/src/components/legend/components/legend-item-timestep/index.js
@@ -92,7 +92,12 @@ export class TimestepContainer extends PureComponent {
 
   formatRange = range => {
     const { minDate, interval } = this.timelineParams;
-    return range.map(r => formatDate(addToDate(minDate, r, interval)));
+    return range.map((r, i) => {
+      // if date is not the start date we should select the end of the interval
+      const toEnd = i !== 0;
+
+      return formatDate(addToDate(minDate, r, interval, toEnd));
+    });
   };
 
   formatValue = value => {

--- a/src/components/legend/components/legend-item-timestep/utils.js
+++ b/src/components/legend/components/legend-item-timestep/utils.js
@@ -1,9 +1,9 @@
 import moment from 'moment';
 
-export const addToDate = (date, count, interval = 'days') => {
+export const addToDate = (date, count, interval = 'days', toEnd) => {
   const d = moment.utc(date);
 
-  return d.add(count, interval);
+  return toEnd ? d.add(count, interval).endOf(interval) : d.add(count, interval);
 };
 
 export const formatDate = (date, format = 'YYYY-MM-DD') => {
@@ -95,4 +95,3 @@ export const gradientConverter = (gradient, minDate, interval) => (
       [dateDiff(val, minDate, interval)]: gradient[val],
     }), {})
 );
-


### PR DESCRIPTION
Currently when we return a changed date range from the legend time step return the date of the beginning of the interval. Example being if I have a time step with `interval: 'years'` and I select `2015` to `2015` the new range becomes `2015-01-01` to `2015-01-01`. This is incorrect. We should return the whole range of 2015.

This should be the case for any interval (days, weeks, months, years).

This PR adds a check to return the `.endOf(interval)` for the `endDate` and `trimEndDate` props.